### PR TITLE
Add missing semicolon to avoid error message

### DIFF
--- a/mac/Workman.bundle/Contents/Resources/English.lproj/InfoPlist.strings
+++ b/mac/Workman.bundle/Contents/Resources/English.lproj/InfoPlist.strings
@@ -3,4 +3,4 @@
 "Workman-P" = "Workman-P";
 "Workman-P Extended" = "Workman-P Extended";
 "Workman-IO" = "Workman-IO";
-"Workman-Dead" = "Workman-Dead"
+"Workman-Dead" = "Workman-Dead";


### PR DESCRIPTION
My project (https://github.com/Lutzifer/keyboardSwitcher) has an issue (https://github.com/Lutzifer/keyboardSwitcher/issues/1) where the error "CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line" appeared, due to this missing semicolon.