### PR TITLE
Update readme to direct to new URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Workman keyboard layouts
 ========================
 
-Workman keyboard layout originally proposed by OJ Bucao at http://www.workmanlayout.com.
+Workman keyboard layout originally proposed by OJ Bucao at http://www.workmanlayout.org.
 
 When learning cold-turkey, try printing the included keyboard image as a desk reference.
 


### PR DESCRIPTION
I know the .org is unofficial, but the .com is no longer available.

Its very tough to find Workman these days by google, since it directs to the offline .com. Could we contribute a static HTML page GitHub Pages page that directs people to the .org site?